### PR TITLE
Potential fix for code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/Frontend/run.py
+++ b/Frontend/run.py
@@ -3,13 +3,15 @@ from app.models import Job, Expense, Service
 
 app = create_app()
 
-# Force debug mode
-app.debug = True
-app.env = "development"
+import os
+
+# Dynamically set debug mode based on the environment
+env = os.getenv('FLASK_ENV', 'production')
+app.debug = env == 'development'
 
 @app.shell_context_processor
 def make_shell_context():
     return {'db': db, 'Job': Job, 'Expense': Expense, 'Service': Service}
 
 if __name__ == '__main__':
-    app.run(debug=True)  # Explicitly enable debug mode
+    app.run(debug=app.debug)  # Dynamically enable/disable debug mode


### PR DESCRIPTION
Potential fix for [https://github.com/bobbyb-debug/mowappdev/security/code-scanning/2](https://github.com/bobbyb-debug/mowappdev/security/code-scanning/2)

To fix the issue, we need to ensure that debug mode is only enabled in a development environment and is disabled in production. This can be achieved by checking the environment variable `FLASK_ENV` or a custom configuration variable to determine the environment. If the environment is set to "development," debug mode can be enabled; otherwise, it should be disabled.

The changes involve:
1. Removing the hardcoded `app.debug = True` and `app.env = "development"`.
2. Modifying the `app.run()` call to dynamically set `debug` based on the environment.
3. Using Python's `os` module to read the environment variable `FLASK_ENV`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
